### PR TITLE
README.md: add Fedora/RHEL/CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ utilisation graphs and other metrics cannot.
 On Arch, the [psi-notify AUR
 package](https://aur.archlinux.org/packages/psi-notify/) is available.
 
+On Fedora and RHEL/CentOS 8, the [psi-notify](https://src.fedoraproject.org/rpms/psi-notify) is available. For RHEL/CentOS you need to enable the [Extra Packages for Enterprise Linux](https://fedoraproject.org/wiki/EPEL) repository.
+
 Otherwise, manual installation is as simple as running `make` and putting the
 resulting `psi-notify` binary in your PATH. You will need `libnotify`
 installed.


### PR DESCRIPTION
psi-notify is coming to Fedora and EPEL. Fedora package should be available by May 16 (unless the test update is upvoted before then), EPEL by May 23. This documentation update links to the source repo though, so it might be safe to merge even before then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cdown/psi-notify/8)
<!-- Reviewable:end -->
