### PR TITLE
Fix time_t size on 32-bit

### DIFF
--- a/psi-notify.c
+++ b/psi-notify.c
@@ -215,7 +215,7 @@ static void config_update_interval(const char *line) {
     }
 
     /* Signed at first to avoid %u shenanigans with negatives */
-    cfg.update_interval = (unsigned int)rvalue;
+    cfg.update_interval = (time_t)rvalue;
 }
 
 static void config_update_log_pressures(const char *line) {
@@ -249,7 +249,7 @@ static void config_reset_user_facing(void) {
 #define WATCHDOG_GRACE_PERIOD_SEC 5
 #define SEC_TO_USEC 1000000
 static void watchdog_update_usec(void) {
-    sd_notifyf(0, "WATCHDOG_USEC=%d",
+    sd_notifyf(0, "WATCHDOG_USEC=%ld",
                (cfg.update_interval + WATCHDOG_GRACE_PERIOD_SEC) * SEC_TO_USEC);
 }
 
@@ -543,8 +543,8 @@ static void suspend_for_remaining_interval(const struct timespec *in) {
         remaining.tv_nsec = 0;
     }
 
-    if (remaining.tv_sec >= (__time_t)cfg.update_interval) {
-        warn("Timer elapsed %d seconds before we completed one event loop.\n",
+    if (remaining.tv_sec >= cfg.update_interval) {
+        warn("Timer elapsed %ld seconds before we completed one event loop.\n",
              cfg.update_interval);
         return;
     }
@@ -598,7 +598,7 @@ static void print_config(void) {
     info("%s:\n\n", header);
 
     printf("      Log pressures: %s\n", cfg.log_pressures ? "true" : "false");
-    printf("      Update interval: %ds\n\n", cfg.update_interval);
+    printf("      Update interval: %lds\n\n", cfg.update_interval);
 
     printf("      Thresholds:\n");
     for_each_arr (i, all_res) {

--- a/psi-notify.c
+++ b/psi-notify.c
@@ -543,7 +543,7 @@ static void suspend_for_remaining_interval(const struct timespec *in) {
         remaining.tv_nsec = 0;
     }
 
-    if (remaining.tv_sec >= cfg.update_interval) {
+    if (remaining.tv_sec >= (__time_t)cfg.update_interval) {
         warn("Timer elapsed %d seconds before we completed one event loop.\n",
              cfg.update_interval);
         return;

--- a/psi-notify.c
+++ b/psi-notify.c
@@ -249,8 +249,8 @@ static void config_reset_user_facing(void) {
 #define WATCHDOG_GRACE_PERIOD_SEC 5
 #define SEC_TO_USEC 1000000
 static void watchdog_update_usec(void) {
-    sd_notifyf(0, "WATCHDOG_USEC=%ld",
-               (cfg.update_interval + WATCHDOG_GRACE_PERIOD_SEC) * SEC_TO_USEC);
+    sd_notifyf(0, "WATCHDOG_USEC=%lld",
+               ((long long)cfg.update_interval + WATCHDOG_GRACE_PERIOD_SEC) * SEC_TO_USEC);
 }
 
 static void config_get_path(char *out) {
@@ -544,8 +544,8 @@ static void suspend_for_remaining_interval(const struct timespec *in) {
     }
 
     if (remaining.tv_sec >= cfg.update_interval) {
-        warn("Timer elapsed %ld seconds before we completed one event loop.\n",
-             cfg.update_interval);
+        warn("Timer elapsed %lld seconds before we completed one event loop.\n",
+             (long long)cfg.update_interval);
         return;
     }
 
@@ -598,7 +598,7 @@ static void print_config(void) {
     info("%s:\n\n", header);
 
     printf("      Log pressures: %s\n", cfg.log_pressures ? "true" : "false");
-    printf("      Update interval: %lds\n\n", cfg.update_interval);
+    printf("      Update interval: %llds\n\n", (long long)cfg.update_interval);
 
     printf("      Thresholds:\n");
     for_each_arr (i, all_res) {

--- a/psi-notify.h
+++ b/psi-notify.h
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <strings.h>
+#include <time.h>
 
 /* Data structures */
 
@@ -30,7 +31,7 @@ typedef struct {
     Resource cpu;
     Resource memory;
     Resource io;
-    unsigned int update_interval;
+    time_t update_interval;
     bool log_pressures;
 } Config;
 


### PR DESCRIPTION
Newer GCCs will fail comparing a `__time_t` with an unsigned int on i686; do the necessary type coercion since we know this will be safe rather than having to use `__time_t` everywhere (its implementation is arch-specific anyway).

```
psi-notify.c: In function 'suspend_for_remaining_interval':
psi-notify.c:546:26: error: comparison of integer expressions of different signedness: '__time_t' {aka 'long int'} and 'unsigned int' [-Werror=sign-compare]
  546 |     if (remaining.tv_sec >= cfg.update_interval) {
      |                          ^~
cc1: all warnings being treated as errors
```

see the Fedora scratch builds:

  https://koji.fedoraproject.org/koji/taskinfo?taskID=44743766

it succeeds on x86_64, fails on i686:

  https://kojipkgs.fedoraproject.org//work/tasks/3799/44743799/build.log

Fixed scratch builds:

  https://koji.fedoraproject.org/koji/taskinfo?taskID=44745335

(it errors out now on s390x, but our s390x builder is a bit flaky and even if it is a real issue it seesms unrelated)

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cdown/psi-notify/14)
<!-- Reviewable:end -->
