### PR TITLE
Add null checks to fix '%s' directive argument is null on s390x

### DIFF
--- a/psi-notify.c
+++ b/psi-notify.c
@@ -397,17 +397,13 @@ static int pressure_check_single_line(FILE *f, const Resource *r) {
                PRESSURE_LINE_LEN_STR
                " avg10=%lf avg60=%lf avg300=%lf total=%*s",
                type, &avg10, &avg60, &avg300) != 4) {
-        if (r->filename) {
-            warn("Can't parse pressures from %s\n", r->filename);
-        }
+        warn("Can't parse pressures from %s\n", strnull(r->filename));
         return -EINVAL;
     }
 
     if (cfg.log_pressures) {
-        if (r->human_name) {
-            info("Current %s pressures: %s avg10=%.2f avg60=%.2f avg300=%.2f\n",
-                 r->human_name, type, avg10, avg60, avg300);
-        }
+        info("Current %s pressures: %s avg10=%.2f avg60=%.2f avg300=%.2f\n",
+             strnull(r->human_name), type, avg10, avg60, avg300);
     }
 
     if (streq(type, "some")) {

--- a/psi-notify.c
+++ b/psi-notify.c
@@ -397,13 +397,17 @@ static int pressure_check_single_line(FILE *f, const Resource *r) {
                PRESSURE_LINE_LEN_STR
                " avg10=%lf avg60=%lf avg300=%lf total=%*s",
                type, &avg10, &avg60, &avg300) != 4) {
-        warn("Can't parse pressures from %s\n", r->filename);
+        if (r->filename) {
+            warn("Can't parse pressures from %s\n", r->filename);
+        }
         return -EINVAL;
     }
 
     if (cfg.log_pressures) {
-        info("Current %s pressures: %s avg10=%.2f avg60=%.2f avg300=%.2f\n",
-             r->human_name, type, avg10, avg60, avg300);
+        if (r->human_name) {
+            info("Current %s pressures: %s avg10=%.2f avg60=%.2f avg300=%.2f\n",
+                 r->human_name, type, avg10, avg60, avg300);
+        }
     }
 
     if (streq(type, "some")) {

--- a/psi-notify.h
+++ b/psi-notify.h
@@ -55,6 +55,7 @@ typedef struct {
 
 #define streq(a, b) (strcmp((a), (b)) == 0)
 #define strceq(a, b) (strcasecmp((a), (b)) == 0)
+#define strnull(s) s ? s : "[null]"
 
 static inline int blank_line_or_comment(const char *s) {
     while (isspace((unsigned char)*s)) {


### PR DESCRIPTION
When building on s390x, the `info` and `warn` macros would fail because GCC
thinks `r->filename` and `r->human_name` could be null. Don't ask why it does not complain on other architectures (x86_64, i686, aarch64, armv7hl, ppc64le).

with `-D_FORTIFY_SOURCE=1`:
https://koji.fedoraproject.org/koji/taskinfo?taskID=44746675
https://kojipkgs.fedoraproject.org//work/tasks/6713/44746713/build.log
```
In file included from psi-notify.c:13:
In function 'pressure_check_single_line',
    inlined from 'pressure_check' at psi-notify.c:449:11,
    inlined from 'check_fuzzers' at psi-notify.c:566:15,
    inlined from 'main' at psi-notify.c:628:9:
psi-notify.h:39:27: error: '%s' directive argument is null [-Werror=format-overflow=]
   39 | #define info(format, ...) printf("INFO: " format, __VA_ARGS__)
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
psi-notify.c:405:9: note: in expansion of macro 'info'
  405 |         info("Current %s pressures: %s avg10=%.2f avg60=%.2f avg300=%.2f\n",
      |         ^~~~
In function 'pressure_check_single_line',
    inlined from 'pressure_check_single_line' at psi-notify.c:392:12,
    inlined from 'pressure_check' at psi-notify.c:449:11,
    inlined from 'check_fuzzers' at psi-notify.c:566:15,
    inlined from 'main' at psi-notify.c:628:9:
psi-notify.h:40:27: error: '%s' directive argument is null [-Werror=format-overflow=]
   40 | #define warn(format, ...) fprintf(stderr, "WARN: " format, __VA_ARGS__)
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
psi-notify.c:400:9: note: in expansion of macro 'warn'
  400 |         warn("Can't parse pressures from %s\n", r->filename);
      |         ^~~~
cc1: all warnings being treated as errors
```

with `-D_FORTIFY_SOURCE=2`:
```
In file included from /usr/include/stdio.h:867,
                 from /usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-io.h:34,
                 from /usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h:38,
                 from /usr/include/libnotify/notification.h:28,
                 from /usr/include/libnotify/notify.h:27,
                 from psi-notify.c:4:
In function 'printf',
    inlined from 'pressure_check_single_line' at psi-notify.c:405:9,
    inlined from 'pressure_check' at psi-notify.c:449:11,
    inlined from 'check_fuzzers' at psi-notify.c:566:15,
    inlined from 'main' at psi-notify.c:628:9:
/usr/include/bits/stdio2.h:107:10: error: '%s' directive argument is null [-Werror=format-overflow=]
  107 |   return __printf_chk (__USE_FORTIFY_LEVEL - 1, __fmt, __va_arg_pack ());
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'fprintf',
    inlined from 'pressure_check_single_line' at psi-notify.c:400:9,
    inlined from 'pressure_check_single_line' at psi-notify.c:392:12,
    inlined from 'pressure_check' at psi-notify.c:449:11,
    inlined from 'check_fuzzers' at psi-notify.c:566:15,
    inlined from 'main' at psi-notify.c:628:9:
/usr/include/bits/stdio2.h:100:10: error: '%s' directive argument is null [-Werror=format-overflow=]
  100 |   return __fprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1, __fmt,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  101 |    __va_arg_pack ());
      |    ~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Adding a check that these are not null allow the compilation to succeed.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cdown/psi-notify/15)
<!-- Reviewable:end -->
