### PR TITLE
[RFC] Update psi-notify.service

### DIFF
--- a/psi-notify.service
+++ b/psi-notify.service
@@ -1,3 +1,8 @@
+[Unit]
+Description=notify on system-wide resource pressure using PSI
+Documentation=man:psi-notify(1)
+PartOf=graphical-session.target
+
 [Service]
 ExecStart=psi-notify
 ExecReload=kill -HUP $MAINPID
@@ -5,8 +10,7 @@ Type=notify
 
 Restart=always
 
+Slice=background.slice
+
 # Will be updated by watchdog_update_usec() once we parsed the config
 WatchdogSec=2s
-
-[Install]
-WantedBy=default.target


### PR DESCRIPTION
* Add description and documentation key
* Declare to be part of graphical-session.target to not start in non-graphical setups.
* Move into the background slice, recommended by https://www.freedesktop.org/software/systemd/man/systemd.special.html#Special%20User%20Slice%20Units